### PR TITLE
Prevent Player From Starting Job At Destination

### DIFF
--- a/PersistentJobsMod/Main.cs
+++ b/PersistentJobsMod/Main.cs
@@ -1,44 +1,139 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 using UnityModManagerNet;
 using Harmony12;
 using System.Reflection;
+using DV.Logic.Job;
 
 namespace PersistentJobsMod
 {
     static class Main
     {
+        private static UnityModManager.ModEntry thisModEntry;
+        private static bool isModBroken = false;
+        private static float initialDistanceRegular = 0f;
+        private static float initialDistanceAnyJobTaken = 0f;
+
         static void Load(UnityModManager.ModEntry modEntry)
         {
             var harmony = HarmonyInstance.Create(modEntry.Info.Id);
             harmony.PatchAll(Assembly.GetExecutingAssembly());
+            modEntry.OnToggle = OnToggle;
+            thisModEntry = modEntry;
+        }
+
+        static bool OnToggle(UnityModManager.ModEntry modEntry, bool isTogglingOn)
+        {
+            if (isModBroken)
+            {
+                return !isTogglingOn;
+            }
+            thisModEntry.Active = isTogglingOn;
+            return true;
+        }
+
+        static void OnCriticalFailure()
+        {
+            isModBroken = true;
+            thisModEntry.Active = false;
         }
 
         [HarmonyPatch(typeof(StationController), "ExpireAllAvailableJobsInStation")]
         class StationController_ExpireAllAvailableJobsInStation_Patch
         {
-            [HarmonyPrefix]
-            static bool SkipJobExpiration()
+            static bool Prefix()
             {
-                return false; // skip the original method entirely
+                // skip the original method entirely when this mod is active
+                // doing so prevents jobs from expiring due to the player's distance from the station center
+                return !thisModEntry.Active;
             }
         }
 
-        [HarmonyPatch(typeof(StationJobGenerationRange), "Awake")]
-        class StationJobGenerationRange_Awake_Patch
+        [HarmonyPatch(typeof(StationJobGenerationRange))]
+        [HarmonyPatchAll]
+        class StationJobGenerationRange_AllMethods_Patch
         {
-            [HarmonyPrefix]
-            static void ExpandDestroyJobsSqrDistanceRegular(StationJobGenerationRange __instance)
+            static void Prefix(StationJobGenerationRange __instance, MethodBase __originalMethod)
             {
-                if (__instance.destroyGeneratedJobsSqrDistanceAnyJobTaken < 4000000f)
+                try
                 {
-                    __instance.destroyGeneratedJobsSqrDistanceAnyJobTaken = 4000000f;
+                    // backup existing values before overwriting
+                    if (initialDistanceRegular < 1f)
+                    {
+                        initialDistanceRegular = __instance.destroyGeneratedJobsSqrDistanceRegular;
+                    }
+                    if (initialDistanceAnyJobTaken < 1f)
+                    {
+                        initialDistanceAnyJobTaken = __instance.destroyGeneratedJobsSqrDistanceAnyJobTaken;
+                    }
+
+                    if (thisModEntry.Active)
+                    {
+                        if (__instance.destroyGeneratedJobsSqrDistanceAnyJobTaken < 4000000f)
+                        {
+                            __instance.destroyGeneratedJobsSqrDistanceAnyJobTaken = 4000000f;
+                        }
+                        __instance.destroyGeneratedJobsSqrDistanceRegular = __instance.destroyGeneratedJobsSqrDistanceAnyJobTaken;
+                    }
+                    else
+                    {
+                        __instance.destroyGeneratedJobsSqrDistanceRegular = initialDistanceRegular;
+                        __instance.destroyGeneratedJobsSqrDistanceAnyJobTaken = initialDistanceAnyJobTaken;
+                    }
                 }
-                __instance.destroyGeneratedJobsSqrDistanceRegular = __instance.destroyGeneratedJobsSqrDistanceAnyJobTaken;
+                catch (Exception e)
+                {
+                    Debug.LogError(string.Format("Exception thrown during StationJobGenerationRange.{0} prefix patch:\n{1}", __originalMethod.Name, e.Message));
+                    OnCriticalFailure();
+                }
+            }
+        }
+
+        [HarmonyPatch(typeof(JobValidator), "ProcessJobOverview")]
+        class JobValidator_ProcessJobOverview_Patch
+        {
+            static void Prefix(List<StationController> ___allStations, DV.Printers.PrinterController ___bookletPrinter, JobOverview jobOverview)
+            {
+                try
+                {
+                    if (!thisModEntry.Active)
+                    {
+                        return;
+                    }
+
+                    Job job = jobOverview.job;
+                    StationController stationController = ___allStations.FirstOrDefault((StationController st) => st.logicStation.availableJobs.Contains(job));
+
+                    if (___bookletPrinter.IsOnCooldown || job.State != JobState.Available || stationController == null)
+                    {
+                        return;
+                    }
+
+                    // expire the job if all associated cars are outside the job destruction range at time of job overview processing
+                    // the base method's logic will handle generating the expired report
+                    StationJobGenerationRange stationRange = Traverse.Create(stationController).Field("stationRange").GetValue<StationJobGenerationRange>();
+                    Task taskWithCarsInRangeOfStation = job.tasks.FirstOrDefault((Task t) =>
+                    {
+                        List<Car> cars = Traverse.Create(t).Field("cars").GetValue<List<Car>>();
+                        Car carInRangeOfStation = cars.FirstOrDefault((Car c) =>
+                        {
+                            TrainCar trainCar = TrainCar.GetTrainCarByCarGuid(c.carGuid);
+                            return trainCar != null && (trainCar.transform.position - stationRange.stationCenterAnchor.position).sqrMagnitude <= stationRange.destroyGeneratedJobsSqrDistanceAnyJobTaken;
+                        });
+                        return carInRangeOfStation != null;
+                    });
+                    if (taskWithCarsInRangeOfStation == null)
+                    {
+                        job.ExpireJob();
+                    }
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError(string.Format("Exception thrown during JobValidator.ProcessJobOverview prefix patch:\n{0}", e.Message));
+                    OnCriticalFailure();
+                }
             }
         }
     }


### PR DESCRIPTION
### Overview
Derail Valley relies on jobs expiring as the player moves a certain distance away from station center to ensure the player starts each job at its departure station. Preventing jobs from expiring when the player moves outside this radius opens up a hack by which the player can wait to start the job until they've arrived at the destination station. This makes the time bonus too easy to achieve and the game less fun overall.

This PR adds logic that causes a job to expire if all its associated train cars are too far away from the departure station. This introduces a chance of expiring a job under seemingly valid conditions—which would be a regression in terms of the goal of this mod—but this chance is reduced by 1) allowing even a single in-range train car to prevent expiration and 2) only checking at the time a job overview is inserted into a job validator.

### Testing
- [x] verify job expires when train cars are moved to another station before starting the job
- [x] verify job can still be started if one train car is left at the departure station