### PR TITLE
Fix More Jobs Targeting Track Than Track Can Accommodate

### DIFF
--- a/PersistentJobsMod/Main.cs
+++ b/PersistentJobsMod/Main.cs
@@ -1100,7 +1100,7 @@ namespace PersistentJobsMod
 						{
 							__result = Utilities.GetRandomFromEnumerable(
 								tracksWithFreeSpace,
-								new System.Random(Environment.TickCount));
+								new System.Random());
 						}
 						return false;
 					}

--- a/PersistentJobsMod/Utilities.cs
+++ b/PersistentJobsMod/Utilities.cs
@@ -252,6 +252,18 @@ namespace PersistentJobsMod
 			return (orderedCargoTypes, pickedCargoGroup);
 		}
 
+		public static void CrawlTaskDFS(Task task, Action<Task> action)
+		{
+			if (task is ParallelTasks || task is SequentialTasks)
+			{
+				Traverse.Create(task)
+					.Field("tasks")
+					.GetValue<IEnumerable<Task>>()
+					.Do(t => CrawlTaskDFS(t, action));
+			}
+			action(task);
+		}
+
 		// taken from StationProcedurationJobGenerator.GetRandomFromList
 		public static T GetRandomFromEnumerable<T>(IEnumerable<T> list, System.Random rng)
 		{


### PR DESCRIPTION
As a side effect of this change, jobs may wind up targeting track types that they wouldn't normally have as a destination track. For example: a transport job with a storage track as its destination.

The order of track preference for each job type is as follows:
* Shunting load jobs
  1. Outbound track (vanilla)
  2. Storage track
  3. Inbound track
* Freight haul jobs
  1. Inbound track (vanilla)
  2. Outbound track
  3. Storage track
* Shunting unload & logistical haul jobs
  1. Storage track (vanilla)
  2. Outbound track
  3. Inbound track

Fixes #7.