### PR TITLE
Generate empty haul jobs

### DIFF
--- a/PersistentJobsMod/JobProceduralGenerationUtilities.cs
+++ b/PersistentJobsMod/JobProceduralGenerationUtilities.cs
@@ -115,6 +115,36 @@ namespace PersistentJobsMod
 			}
 		}
 
+		public static Dictionary<StationController, List<List<TrainCar>>> ExtractEmptyHaulTrainSets(
+			Dictionary<StationController, List<(List<TrainCar>, List<CargoGroup>)>> cgsPerTcsPerSc)
+		{
+			Dictionary<StationController, List<List<TrainCar>>> tcsPerSc
+				= new Dictionary<StationController, List<List<TrainCar>>>();
+
+			foreach (StationController sc in cgsPerTcsPerSc.Keys)
+			{
+				// need to copy the list for iteration b/c we'll be editing the list during iteration
+				var cgsPerTcsCopy = new List<(List<TrainCar>, List<CargoGroup>)>(cgsPerTcsPerSc[sc]);
+				foreach ((List<TrainCar>, List<CargoGroup>) cgsPerTcs in cgsPerTcsCopy)
+				{
+					// no cargo groups indicates a train car type that cannot carry cargo from its nearest station
+					// extract it to have an empty haul job generated for it
+					if (cgsPerTcs.Item2.Count == 0)
+					{
+						if (!tcsPerSc.ContainsKey(sc))
+						{
+							tcsPerSc.Add(sc, new List<List<TrainCar>>());
+						}
+
+						tcsPerSc[sc].Add(cgsPerTcs.Item1);
+						cgsPerTcsPerSc[sc].Remove(cgsPerTcs);
+					}
+				}
+			}
+
+			return tcsPerSc;
+		}
+
 		public static void PopulateCargoGroupsPerLoadedTrainCarSet(
 			Dictionary<StationController, List<(List<TrainCar>, List<CargoGroup>)>> cgsPerTcsPerSc)
 		{


### PR DESCRIPTION
Generate empty haul jobs for train car sets with no cargo groups at nearest station. Closes #12.

### Before job generation
![persistent-jobs-1-before-job-generation](https://user-images.githubusercontent.com/66900153/88147199-bedc9b00-cbb1-11ea-8118-c9a73ae7c92b.jpg)

### After job generation
![persistent-jobs-2-after-job-generation](https://user-images.githubusercontent.com/66900153/88147208-c3a14f00-cbb1-11ea-9210-c70819947fd8.jpg)
